### PR TITLE
fix: 4 remaining Windows install bugs (v1.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning: [Semantic Versioning](https://semver.org/).
 
+## [1.1.4] — 2026-04-16
+
+### Fixed
+- `install.py`: Python 3.14+ blocked at startup with an actionable error message;
+  ChromaDB's native layer is incompatible with Python 3.14+
+- `install.py` `main()`: `PYTHONUTF8=1` set via `os.environ.setdefault` before
+  any subprocess is spawned — prevents `UnicodeEncodeError` on Windows CP1252
+  consoles when longhand's rich output contains box-drawing characters
+- `install.py` `_find_context_mode_dir()`: plugin cache excluded from search —
+  running `node install.js` from the cache (src == dest) silently corrupted
+  the install; cache presence is now detected via `is_context_mode_complete()`
+- `install.py` `main()`: when Context-Mode is already installed via the plugin
+  system but no external source directory exists, the installer now skips
+  correctly instead of prompting to clone or exiting with an error
+- `install.py` `_dedup_hooks()`: duplicate hook entries produced by repeated
+  `longhand setup` runs are now removed from `settings.json` automatically
+
+### Added
+- README.md: Python 3.14 removed from tested-versions table; requirement
+  clarified as Python 3.10–3.13
+
 ## [1.1.2] — 2026-04-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ versions is untested.
 |------|---------------|
 | Longhand | 0.5.5 |
 | Context-Mode | 1.6.0 |
-| Python | 3.14.3 (pre-release; 3.10+ supported) |
+| Python | 3.10–3.13 required (3.14+ not supported) |
 | Node.js | 18+ |
 
 Pin Longhand if you need a reproducible install:

--- a/USER-MANUAL.md
+++ b/USER-MANUAL.md
@@ -137,7 +137,7 @@ Here is what happens from the moment you send a message to Claude through to the
 ### Before you start
 
 You need:
-- **Python 3.10 or newer** — check by running `python --version` in your terminal
+- **Python 3.10–3.13** — check by running `python --version` in your terminal (Python 3.14+ is not supported — ChromaDB, used by Longhand, is incompatible with it)
 - **Node.js 18 or newer** — check by running `node --version` in your terminal
 - **Claude Code** installed (the command-line tool from Anthropic)
 - **The stack repo cloned to your computer** — see below
@@ -234,6 +234,15 @@ The installer checks your Python version before starting. If it reports Python i
 - **Linux:** Run `sudo apt install python3` or the equivalent for your distribution.
 
 After installing, open a new terminal window and run `python --version` to confirm the version, then retry.
+
+### `install.py` says Python 3.14+ is not supported
+
+Longhand uses ChromaDB, which has a native extension that is incompatible with Python 3.14+. You need Python 3.10–3.13.
+
+- **Windows:** Install Python 3.13 from [python.org/downloads](https://python.org/downloads), then re-run with: `py -3.13 install.py`
+- **macOS/Linux:** Use pyenv to install 3.13: `pyenv install 3.13 && pyenv local 3.13`
+
+Python 3.14 support depends on ChromaDB releasing a compatible version. Check [github.com/chroma-core/chroma](https://github.com/chroma-core/chroma) for updates.
 
 ### `install.py` fails partway through
 

--- a/docs/discussion-seeds.md
+++ b/docs/discussion-seeds.md
@@ -17,7 +17,7 @@ Hey — Scott here. Thanks for checking this out.
 
 So I built a single skill that does all of it in the right order, with timestamped config backups, per-tool idempotency checks, and a post-install verifier that tells you exactly what passed and what to retry.
 
-**Current state (v1.1.1):** Install-only, three tools, 75 tests, verified on Python 3.14.3 and Node 18+. Two install paths: `python install.py` (standalone, no active Claude Code session needed) and `/stack` (Claude Code skill). The verifier checks config wiring but not live MCP server health — `longhand doctor` and `claude mcp list` are still the runtime truth.
+**Current state (v1.1.4):** Install-only, three tools, 75 tests, requires Python 3.10–3.13 (3.14+ not supported — ChromaDB incompatibility) and Node 18+. Two install paths: `python install.py` (standalone, no active Claude Code session needed) and `/stack` (Claude Code skill). The verifier checks config wiring but not live MCP server health — `longhand doctor` and `claude mcp list` are still the runtime truth.
 
 **What's coming:** Uninstall support, richer verifier output, and possibly support for additional tools in the stack. Nothing is on a hard timeline — this is a tool I use myself, and I ship when it's ready.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -451,7 +451,7 @@
   <div class="container">
     <div class="section-label">Quick Start</div>
     <h2>Two ways to install</h2>
-    <p class="lead">Requires Python 3.10+, Node.js 18+, and the Claude Code CLI. Pick the path that fits your workflow.</p>
+    <p class="lead">Requires Python 3.10–3.13 (3.14+ not supported), Node.js 18+, and the Claude Code CLI. Pick the path that fits your workflow.</p>
 
     <!-- Path toggle labels -->
     <div style="display:flex;gap:12px;margin-bottom:28px;flex-wrap:wrap">
@@ -556,7 +556,7 @@
         </tr>
         <tr>
           <td>Python</td>
-          <td>3.14.3 (pre-release; 3.10+ supported)</td>
+          <td>3.10–3.13 required (3.14+ not supported)</td>
           <td>Prerequisite</td>
           <td>Powers Longhand + verify.py</td>
         </tr>

--- a/install.py
+++ b/install.py
@@ -11,15 +11,24 @@ Usage:
 """
 from __future__ import annotations
 
-__version__ = "1.1.2"
+__version__ = "1.1.4"
 
 import importlib.util
+import json
 import os
 import pathlib
 import shutil
 import subprocess
 import sys
 import datetime
+
+if sys.version_info >= (3, 14):
+    print(
+        "Error: Python 3.14+ is not supported.\n"
+        "ChromaDB's native layer (used by Longhand) is incompatible with Python 3.14+.\n"
+        "Re-run with Python 3.10–3.13:  py -3.13 install.py"
+    )
+    sys.exit(1)
 
 
 # ── Terminal colour helpers ────────────────────────────────────────────────────
@@ -267,15 +276,10 @@ def _is_context_mode_install_js(path: pathlib.Path) -> bool:
 
 # ── Context-Mode discovery ─────────────────────────────────────────────────────
 def _find_context_mode_dir() -> pathlib.Path | None:
-    # 1. Plugin cache — highest confidence, check first
-    cache = HOME / ".claude" / "plugins" / "cache"
-    if cache.exists():
-        for p in cache.rglob("install.js"):
-            if ("context-mode" in str(p) or "context_mode" in str(p)) \
-                    and _is_context_mode_install_js(p):
-                return p.parent
+    # Do NOT search the plugin cache — install.js fails when src == dest.
+    # Cache presence is detected separately via is_context_mode_complete().
 
-    # 2. Bounded Python-native walk (cross-platform — no 'find' dependency).
+    # Bounded Python-native walk (cross-platform — no 'find' dependency).
     # Skips common system/tool directories that will never contain Context-Mode.
     for depth1 in HOME.iterdir():
         try:
@@ -386,8 +390,39 @@ def restore_configs(ts: str) -> None:
             _warn(f"No backup found for {src_name} (was not present before install)")
 
 
+# ── Hook deduplication ────────────────────────────────────────────────────────
+def _dedup_hooks() -> None:
+    """Remove duplicate hook entries added by repeated longhand setup runs."""
+    if not SETTINGS.exists():
+        return
+    try:
+        data = json.loads(SETTINGS.read_text())
+    except (json.JSONDecodeError, OSError):
+        return
+    hooks = data.get("hooks", {})
+    changed = False
+    for event, entries in hooks.items():
+        seen = []
+        deduped = []
+        for entry in entries:
+            key = json.dumps(entry, sort_keys=True)
+            if key not in seen:
+                seen.append(key)
+                deduped.append(entry)
+        if len(deduped) != len(entries):
+            hooks[event] = deduped
+            changed = True
+    if changed:
+        SETTINGS.write_text(json.dumps(data, indent=2))
+        _ok("Deduplicated hook entries in settings.json")
+
+
 # ── Entry point ───────────────────────────────────────────────────────────────
 def main() -> None:
+    # Ensure Unicode output works on Windows consoles with narrow codepages (e.g. CP1252).
+    # longhand's rich-based output prints → and box-drawing chars that CP1252 can't encode.
+    os.environ.setdefault("PYTHONUTF8", "1")
+
     # Verify-only mode
     if "--verify" in sys.argv:
         v = _load_verify()
@@ -413,31 +448,35 @@ def main() -> None:
     # prompts before installation starts, not mid-flow as a surprise.
     ctx_dir = _find_context_mode_dir()
     if ctx_dir is None:
-        print()
-        _warn("Context-Mode not found in plugin cache or home directory")
-        try:
-            reply = input("  Clone scottconverse/context-mode now? [Y/n]: ").strip().lower()
-        except KeyboardInterrupt:
-            print()
-            reply = "n"
-        if reply in ("", "y", "yes"):
-            clone_target = HOME / ".claude" / "plugins" / "context-mode"
-            _step(f"git clone → {clone_target}")
-            code = _run([
-                "git", "clone",
-                "https://github.com/scottconverse/context-mode",
-                str(clone_target),
-            ])
-            if code != 0:
-                _fail("Clone failed — install context-mode manually and re-run")
-                sys.exit(1)
-            ctx_dir = clone_target
-            _ok(f"Context-Mode cloned")
+        if is_context_mode_complete(v):
+            # Already installed via plugin system — no source dir needed
+            _ok("Context-Mode found (plugin system)")
         else:
-            _fail("Context-Mode required — clone manually and re-run")
-            sys.exit(1)
+            print()
+            _warn("Context-Mode not found in home directory")
+            try:
+                reply = input("  Clone scottconverse/context-mode now? [Y/n]: ").strip().lower()
+            except KeyboardInterrupt:
+                print()
+                reply = "n"
+            if reply in ("", "y", "yes"):
+                clone_target = HOME / ".claude" / "plugins" / "context-mode"
+                _step(f"git clone → {clone_target}")
+                code = _run([
+                    "git", "clone",
+                    "https://github.com/scottconverse/context-mode",
+                    str(clone_target),
+                ])
+                if code != 0:
+                    _fail("Clone failed — install context-mode manually and re-run")
+                    sys.exit(1)
+                ctx_dir = clone_target
+                _ok("Context-Mode cloned")
+            else:
+                _fail("Context-Mode required — clone manually and re-run")
+                sys.exit(1)
     else:
-        _ok(f"Context-Mode found")
+        _ok("Context-Mode found")
 
     # Backup
     _header("Config backup")
@@ -450,11 +489,16 @@ def main() -> None:
     else:
         if not install_longhand():
             sys.exit(1)
+    _dedup_hooks()
 
     # Context-Mode
     if is_context_mode_complete(v):
         _header("Context-Mode  (context layer)")
         _ok("Fully installed — skipping")
+    elif ctx_dir is None:
+        _header("Context-Mode  (context layer)")
+        _fail("No source directory found. Clone context-mode manually and re-run.")
+        sys.exit(1)
     else:
         if not install_context_mode(ctx_dir):
             sys.exit(1)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -182,12 +182,14 @@ def test_is_context_mode_install_js_handles_missing_file(tmp_path):
 
 # ── _find_context_mode_dir() ───────────────────────────────────────────────────
 
-def test_find_context_mode_dir_finds_plugin_cache(tmp_path, monkeypatch):
+def test_find_context_mode_dir_excludes_plugin_cache(tmp_path, monkeypatch):
+    # Cache is intentionally excluded — running install.js from src==dest corrupts the install.
+    # Cache presence is detected separately via is_context_mode_complete().
     cache = tmp_path / ".claude" / "plugins" / "cache" / "context-mode"
     cache.mkdir(parents=True)
     (cache / "install.js").write_text(CTX_JS_CONTENT)
     monkeypatch.setattr(install, "HOME", tmp_path)
-    assert install._find_context_mode_dir() == cache
+    assert install._find_context_mode_dir() is None
 
 
 def test_find_context_mode_dir_finds_at_depth2(tmp_path, monkeypatch):
@@ -240,8 +242,8 @@ def test_find_context_mode_dir_ignores_install_js_without_matching_content(tmp_p
     assert install._find_context_mode_dir() is None
 
 
-def test_find_context_mode_dir_prefers_plugin_cache_over_home_walk(tmp_path, monkeypatch):
-    # Both cache and home-walk match — cache should win (checked first)
+def test_find_context_mode_dir_returns_home_walk_when_cache_also_present(tmp_path, monkeypatch):
+    # Cache is excluded — home-walk result wins even when cache also exists.
     cache = tmp_path / ".claude" / "plugins" / "cache" / "context-mode"
     cache.mkdir(parents=True)
     (cache / "install.js").write_text(CTX_JS_CONTENT)
@@ -251,7 +253,7 @@ def test_find_context_mode_dir_prefers_plugin_cache_over_home_walk(tmp_path, mon
     (other / "install.js").write_text(CTX_JS_CONTENT)
 
     monkeypatch.setattr(install, "HOME", tmp_path)
-    assert install._find_context_mode_dir() == cache
+    assert install._find_context_mode_dir() == other
 
 
 def test_find_context_mode_dir_accepts_underscore_naming(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes the 4 bugs identified during the live Windows install session but not included in PR #9:

- **Python 3.14 gate** — installer exits immediately with an actionable error message; ChromaDB's native layer is incompatible with 3.14+
- **UTF-8 auto-set** — `PYTHONUTF8=1` set via `os.environ.setdefault` before any subprocess is spawned, preventing `UnicodeEncodeError` on Windows CP1252 consoles
- **Context-Mode src=dest** — plugin cache excluded from `_find_context_mode_dir()`; running `node install.js` from the cache directory (src == dest) silently corrupted the install; cache presence is now detected via `is_context_mode_complete()`
- **Longhand hook dedup** — `_dedup_hooks()` removes duplicate hook entries from `settings.json` produced by repeated `longhand setup` runs

## Test plan

- [ ] 75 tests pass (`py -3.13 -m pytest tests/ -q`) — confirmed locally
- [ ] Two tests updated to reflect intentional cache-exclusion behavior (`test_find_context_mode_dir_excludes_plugin_cache`, `test_find_context_mode_dir_returns_home_walk_when_cache_also_present`)
- [ ] All 6 doc artifacts updated: README, CHANGELOG, USER-MANUAL, landing page, discussion seeds
- [ ] Depends on PR #9 merging first (this branch is off `master`, not off `fix/windows-install-bugs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)