### PR TITLE
docs: refresh tested-versions for Longhand 0.8.1 + Context-Mode 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning: [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- Tested-versions table in `README.md` refreshed to current upstream:
+  Longhand `0.5.5` → `0.8.1`, Context-Mode `1.6.0` → `1.6.1`.
+- Added explicit **Last validated** date line (2026-04-24) to README.
+- Longhand pin example bumped to `pip install longhand==0.8.1`.
+
+### Notes
+- stack's pytest suite passes 75/75 against current `scripts/verify.py`.
+- Longhand install surfaces stack invokes (`longhand setup`,
+  `prompt-hook install`, `mcp-server`) are unchanged across the
+  0.5.5 → 0.8.1 range per upstream CHANGELOG — additive changes only
+  (`reconcile` MCP tool, staleness detection, recall narrative fixes).
+- End-to-end `install.py` run was not re-exercised against these
+  specific versions during this refresh. No code changes to
+  `install.py` or `scripts/verify.py`.
+
 ## [1.1.2] — 2026-04-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -80,15 +80,24 @@ versions is untested.
 
 | Tool | Tested version |
 |------|---------------|
-| Longhand | 0.5.5 |
-| Context-Mode | 1.6.0 |
+| Longhand | 0.8.1 |
+| Context-Mode | 1.6.1 |
 | Python | 3.14.3 (pre-release; 3.10+ supported) |
 | Node.js | 18+ |
+
+**Last validated:** 2026-04-24 — stack's own pytest suite passes 75/75
+against current `scripts/verify.py` logic. Longhand's install surfaces
+(`longhand setup`, `longhand prompt-hook install`, `longhand mcp-server`)
+are unchanged across the 0.5.5 → 0.8.1 range per upstream CHANGELOG
+(additive changes only). Context-Mode 1.6.0 → 1.6.1 is a patch bump.
+End-to-end `install.py` run was not re-exercised against these specific
+versions during this refresh — run `longhand doctor` and `claude mcp list`
+after install to confirm runtime health.
 
 Pin Longhand if you need a reproducible install:
 
 ```bash
-pip install longhand==0.5.5
+pip install longhand==0.8.1
 ```
 
 Context-Mode is installed from a local clone — pin by checking out the


### PR DESCRIPTION
## Summary

Light refresh of the tested-versions claim in `README.md` + matching `[Unreleased]` `CHANGELOG.md` entry. No code changes.

## What changed

- **`README.md`** tested-versions table: Longhand `0.5.5` → `0.8.1`, Context-Mode `1.6.0` → `1.6.1`.
- New **"Last validated: 2026-04-24"** line under the table, transparent about what "validated" means in this pass.
- Longhand pin example: `pip install longhand==0.5.5` → `pip install longhand==0.8.1`.
- **`CHANGELOG.md`** `[Unreleased]` > `Changed` + `Notes` sections documenting the refresh and its validation depth.

## Validation

- `python -m pytest tests/` — **75/75 passing** against current `scripts/verify.py`.
- Longhand install surfaces stack invokes (`longhand setup`, `prompt-hook install`, `mcp-server`) are **unchanged** across the 0.5.5 → 0.8.1 range per [Longhand's CHANGELOG](https://github.com/Wynelson94/longhand/blob/main/CHANGELOG.md): additive changes only (`reconcile` MCP tool, staleness detection, recall narrative fixes).
- Context-Mode 1.6.0 → 1.6.1 is a patch bump.

## Out of scope

- No changes to `install.py` or `scripts/verify.py` — no behavior changes.
- No end-to-end `install.py` run re-exercised against these versions in this refresh (avoided to prevent mutating the maintainer's live environment). Users doing a fresh install should rely on the existing "Known limitation" / `longhand doctor` / `claude mcp list` post-install health checks.
- No branding, positioning, landing-page, or test-suite changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)