### PR TITLE
audit-sweep 2026-04-25: SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take the security of this project seriously. If you discover a security vulnerability, please report it responsibly.
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, report them via [GitHub Security Advisories](https://github.com/scottconverse/stack/security/advisories/new). This allows us to triage and address the issue privately before public disclosure.
+
+When reporting, please include:
+
+- A clear description of the vulnerability
+- Steps to reproduce the issue
+- Affected versions
+- Potential impact
+- Any suggested mitigation or fix
+
+## Supported Versions
+
+Only the latest minor release receives security updates. Older minor releases are not patched — please upgrade to the latest version to receive security fixes.
+
+| Version       | Supported |
+| ------------- | --------- |
+| Latest minor  | Yes       |
+| Older         | No        |
+
+## Response SLA
+
+We aim to respond to security reports on the following timeline:
+
+- **Initial acknowledgment:** within 7 days of report
+- **Triage and severity assessment:** within 14 days of report
+- **Fix or mitigation released:** within 30 days for high/critical severity issues
+
+Lower-severity issues may take longer to resolve and will be communicated case-by-case.
+
+## Disclosure Policy
+
+We follow coordinated disclosure. Once a fix is released, we will publish a security advisory crediting the reporter (unless anonymity is requested) and describing the vulnerability and remediation.
+
+## Scope
+
+This policy covers the code in this repository. Issues in upstream dependencies should be reported to the relevant upstream project, though we appreciate a heads-up so we can update our pins.
+
+Thank you for helping keep this project and its users safe.


### PR DESCRIPTION
## Summary

audit-sweep 2026-04-25 for scottconverse/stack.

### Auto-fixes applied
- **SECURITY.md added** — vuln reporting via GitHub Security Advisories, supported versions = latest minor, 7/14/30-day SLA.

### Skipped (not applicable)
- **GHA pin bumps (3a)** — no `.github/workflows` directory exists in this repo.
- **Broken doc links (3c)** — skipped this run for time budget.

### Verification
- Branch: `audit-sweep-2026-04-25`
- Single new file (SECURITY.md, 46 lines)
- Diff well under 800-line threshold; no large-change tag required.